### PR TITLE
Prevent duplicate chat rooms

### DIFF
--- a/chit_chat/serializers.py
+++ b/chit_chat/serializers.py
@@ -59,4 +59,5 @@ class RoomSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         member_pks = [member.pk for member in validated_data['members']]
-        return Room.objects.filter(members__in=member_pks).annotate(member_count=Count('members')).filter(member_count=len(member_pks)).first() or super().create(validated_data)
+        room = Room.objects.filter(members__in=member_pks).annotate(member_count=Count('members')).filter(member_count=len(member_pks)).first()
+        return room or super().create(validated_data)

--- a/chit_chat/serializers.py
+++ b/chit_chat/serializers.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.db.models import Count
 from rest_framework import serializers, exceptions
 
 from chit_chat.models import Room, Message
@@ -55,3 +56,7 @@ class RoomSerializer(serializers.ModelSerializer):
             raise exceptions.ValidationError('Must contain at least one user other than the requestor in this list.')
         non_requestor_users.append(requestor)
         return users
+
+    def create(self, validated_data):
+        member_pks = [member.pk for member in validated_data['members']]
+        return Room.objects.filter(members__in=member_pks).annotate(member_count=Count('members')).filter(member_count=len(member_pks)).first() or super().create(validated_data)

--- a/chit_chat/viewsets.py
+++ b/chit_chat/viewsets.py
@@ -1,6 +1,5 @@
-from rest_framework import viewsets, mixins, status
-from django.db.models import Max, Count
-from rest_framework.response import Response
+from rest_framework import viewsets, mixins
+from django.db.models import Max
 
 from chit_chat.models import Room
 from chit_chat.serializers import RoomSerializer
@@ -23,16 +22,3 @@ class RoomViewSet(
             'members',
         )
         return qs
-
-    def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        data = serializer.validated_data
-        member_pks = [member.pk for member in data['members']]
-        if room := Room.objects.filter(members__in=member_pks).annotate(member_count=Count('members')).filter(member_count=len(member_pks)).first():
-            data = self.get_serializer(room).data
-        else:
-            self.perform_create(serializer)
-            data = serializer.data
-        headers = self.get_success_headers(data)
-        return Response(data, status=status.HTTP_201_CREATED, headers=headers)

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -17,6 +17,18 @@ class TestChat(APITestCase):
         resp = self.client.post(reverse('room-list'), data=room_data)
         assert resp.status_code == 201
 
+    def test_attempt_to_create_duplicate_rooms_results_in_original_being_returned(self):
+        room_data = {
+            'members': [UserFactory().pk]
+        }
+        resp = self.client.post(reverse('room-list'), data=room_data)
+        assert resp.status_code == 201
+        room_id = resp.json()['id']
+
+        resp = self.client.post(reverse('room-list'), data=room_data)
+        assert resp.status_code == 201
+        assert room_id == resp.json()['id']
+
     def test_room_create_requires_another_user(self):
         room_data = {
             'members': [self.user.pk]


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 


# A brief description of the purpose of the changes contained in this PR.
If a user tries to create a room with the same members as a room that already exists, Django responds to that `POST` request with the original room. This way, we prevent duplicate rooms from being created.


# Misc. comments
Should be able to change one line if we decide to add optional names to the `Room` object.


# Checklist
- [x] Code review by me 
- [ ] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge
