### PR TITLE
Only group_discard chat rooms if user is authenticated during disconnect.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9']
-        django-version: ['>=3']
+        python-version: ['3.8', '3.9', '3.10']
+        django-version: ['<4', '>=4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
-        django-version: ['<3.2', '3.2']
+        django-version: ['<3.2', '==3.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
-        django-version: ['<4', '>=4']
+        django-version: ['<3.2', '3.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/chit_chat/consumers.py
+++ b/chit_chat/consumers.py
@@ -52,8 +52,10 @@ class ChatRoomConsumer(AsyncWebsocketConsumer):
         await self.accept()
 
     async def disconnect(self, close_code):
-        for pk in await self.get_chat_room_pks(self.scope['user']):
-            await self.channel_layer.group_discard(str(pk), self.channel_name)
+        user = self.scope['user']
+        if user.is_authenticated:
+            for pk in await self.get_chat_room_pks(self.scope['user']):
+                await self.channel_layer.group_discard(str(pk), self.channel_name)
 
     async def receive(self, text_data=None, bytes_data=None):
         user = self.scope['user']

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ channels==3.0.3
 factory-boy==3.2.0
 
 # tests
-pytest==6.2.3
+pytest==6.2.5
 pytest-django==4.2.0
 pytest-pythonpath==0.7.3
 pytest-asyncio==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ twine==3.1.1
 # django stuff
 Django==3.2
 djangorestframework==3.12.4
+pytz==2022.1
 
 # Channels
 channels==3.0.3


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 


# A brief description of the purpose of the changes contained in this PR.
These errors pop up everywhere we use this if a user opens a connection to the websocket, but fails to authenticate. Overflows the logging buffer on Heroku.

<img width="1333" alt="image" src="https://user-images.githubusercontent.com/21694127/172267383-7d53cc0b-d436-42bb-9894-d3a862bafc89.png">



# Misc. comments
We might look more into the future why these users are unauthenticated, but this django app should handle the case that they fail to authenticate without killing a server worker.

# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge
