### PR TITLE
Add id field to websocket response when chat message is created.

### DIFF
--- a/chit_chat/consumers.py
+++ b/chit_chat/consumers.py
@@ -74,6 +74,7 @@ class ChatRoomConsumer(AsyncWebsocketConsumer):
                             'room': message.room.pk,
                             'text': message.text,
                             'time': message.created_when.isoformat(),
+                            'id': message.id,
                         }
                     )
 
@@ -105,6 +106,7 @@ class ChatRoomConsumer(AsyncWebsocketConsumer):
                 'text': event.get('text'),
                 'room': event.get('room'),
                 'time': event.get('time'),
+                'id': event.get('id'),
             })
         )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ name = django-chit-chat
 author = Bailey Trefts
 author_email = bailey@ckcollab.com
 description = chat for projects we help maintain @ ckc
-version = 0.0.8
+version = 0.0.9
 url = https://github.com/ckc-org/django-chit-chat
 keywords =
   django

--- a/tests/integration/test_chat_async.py
+++ b/tests/integration/test_chat_async.py
@@ -96,6 +96,7 @@ async def test_user_is_able_to_connect_and_send_message_after_disconnecting():
 
     assert resp['text'] == messages[0].text
     assert resp['time']
+    assert resp['id'] == messages[0].id
 
     await communicator.disconnect()
 
@@ -149,7 +150,13 @@ async def test_serializer_hook():
 
     resp = await communicator.receive_json_from()
     resp.pop('time')
-    assert resp == {'room': room.pk, 'text': 'hello', 'type': 'chat', 'user': user.pk}
+    assert resp == {
+        'room': room.pk,
+        'text': 'hello',
+        'type': 'chat',
+        'user': user.pk,
+        'id': (await get_messages_from_room(room))[-1].id
+    }
 
     ckc_chat_settings = {
         'MESSAGE': ChatTestSerializer,


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab


# A brief description of the purpose of the changes contained in this PR.
Title says it all


# To be addressed in the future:
[Use serializer to send data to chat-message recipients](https://github.com/ckc-org/django-chit-chat/issues/11)


# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge
